### PR TITLE
IDE Compatibility plugin verifier via GitHub Actions build

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -1,0 +1,37 @@
+name: IntelliJ Platform Plugin Compatibility
+
+on:
+  push:
+
+jobs:
+  compatibility:
+    name: Ensure plugin compatibility against 2019.3 for IDEA Community, IDEA Ultimate, PyCharm Community, GoLand, CLion, and the latest EAP snapshot of IDEA Community.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v1
+
+      - name: Setup Java 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: Build the plugin using Gradle
+        run: ./gradlew buildPlugin
+
+      - name: Verify Plugin on IntelliJ Platforms
+        id: verify
+        uses: ChrisCarini/intellij-platform-plugin-verifier-action@v0.0.2
+        with:
+          ide-versions: |
+            ideaIC:2019.3
+            ideaIU:2019.3
+            pycharmPC:2019.3
+            goland:2019.3
+            clion:2019.3
+            ideaIC:LATEST-EAP-SNAPSHOT
+
+      - name: Get log file path and print contents
+        run: |
+          echo "The verifier log file [${{steps.verify.outputs.verification-output-log-filename}}] contents : " ;
+          cat ${{steps.verify.outputs.verification-output-log-filename}}

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   compatibility:
-    name: Ensure plugin compatibility against 2019.3 for IDEA Community, IDEA Ultimate, PyCharm Community, GoLand, CLion, and the latest EAP snapshot of IDEA Community.
+    name: Ensure plugin compatibility against 2020.1 for IDEA Community, IDEA Ultimate
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -24,12 +24,8 @@ jobs:
         uses: ChrisCarini/intellij-platform-plugin-verifier-action@v0.0.2
         with:
           ide-versions: |
-            ideaIC:2019.3
-            ideaIU:2019.3
-            pycharmPC:2019.3
-            goland:2019.3
-            clion:2019.3
-            ideaIC:LATEST-EAP-SNAPSHOT
+            ideaIC:2020.1
+            ideaIU:2020.1
 
       - name: Get log file path and print contents
         run: |


### PR DESCRIPTION
Uses the IntelliJ Plugin Verifier to validate IDe compatibility.  I only setup the current release of IDEA as a proof of concept.  Modify as you see fit.