### PR TITLE
Add a "Open workflow" action

### DIFF
--- a/src/main/java/org/github/otanikotani/workflow/GitHubWorkflowToolTabsContentManager.kt
+++ b/src/main/java/org/github/otanikotani/workflow/GitHubWorkflowToolTabsContentManager.kt
@@ -29,7 +29,10 @@ class GitHubWorkflowToolTabsContentManager(private val project: Project,
     @CalledInAwt
     fun focusTab(remoteUrl: GitRemoteUrlCoordinates) {
         LOG.debug("focusTab")
-        val content = viewContentManager.findContents { it.remoteUrl == remoteUrl }.firstOrNull() ?: return
+        val content = viewContentManager.findContents { it.remoteUrl == remoteUrl }.firstOrNull() ?: run {
+            addTab(remoteUrl, Disposer.newDisposable())
+            viewContentManager.findContents { it.remoteUrl == remoteUrl }.firstOrNull()
+        } ?: return
         ToolWindowManager.getInstance(project).getToolWindow(ChangesViewContentManager.TOOLWINDOW_ID)?.show {
             viewContentManager.setSelectedContent(content, true)
         }

--- a/src/main/java/org/github/otanikotani/workflow/action/GitHubWorkflowShowActionGroup.kt
+++ b/src/main/java/org/github/otanikotani/workflow/action/GitHubWorkflowShowActionGroup.kt
@@ -1,0 +1,46 @@
+package org.github.otanikotani.workflow.action
+
+import com.intellij.openapi.actionSystem.*
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.project.DumbAwareAction
+import com.intellij.util.containers.map2Array
+import org.github.otanikotani.workflow.GitHubWorkflowRunManager
+import org.jetbrains.plugins.github.util.GHGitRepositoryMapping
+import org.jetbrains.plugins.github.util.GHProjectRepositoriesManager
+import org.jetbrains.plugins.github.util.GitRemoteUrlCoordinates
+
+class GitHubWorkflowShowActionGroup : ActionGroup("Open Workflow Tab", true), DumbAware {
+
+    override fun update(e: AnActionEvent) {
+        val data = getGithubRemotes(e.dataContext)
+        e.presentation.isEnabledAndVisible = data != null && data.isNotEmpty()
+    }
+
+    override fun actionPerformed(e: AnActionEvent) {
+        val firstRemote = getGithubRemotes(e.dataContext)?.firstOrNull() ?: return
+        GitHubWorkflowShowAction(firstRemote).actionPerformed(e)
+    }
+
+    override fun getChildren(e: AnActionEvent?): Array<AnAction> {
+        e ?: return emptyArray()
+        val remotes = getGithubRemotes(e.dataContext)?.takeIf { it.size > 1 } ?: return emptyArray()
+        return remotes.map2Array(::GitHubWorkflowShowAction)
+    }
+
+    override fun canBePerformed(context: DataContext): Boolean {
+        return getGithubRemotes(context)?.size == 1
+    }
+
+    private fun getGithubRemotes(dataContext: DataContext): List<GitRemoteUrlCoordinates>? {
+        val project = dataContext.getData(CommonDataKeys.PROJECT) ?: return null
+        return project.service<GHProjectRepositoriesManager>().knownRepositories.map(GHGitRepositoryMapping::gitRemote)
+    }
+}
+
+class GitHubWorkflowShowAction(val remote: GitRemoteUrlCoordinates) : DumbAwareAction(remote.remote.name + ": " + remote.remote.firstUrl) {
+    override fun actionPerformed(e: AnActionEvent) {
+        val project = e.dataContext.getData(CommonDataKeys.PROJECT) ?: return
+        project.service<GitHubWorkflowRunManager>().showTab(remote)
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -78,6 +78,11 @@
             <action id="Github.Workflow.Log.List.Reload"
                     class="org.github.otanikotani.workflow.action.GitHubWorkflowLogReloadAction"/>
         </group>
+
+        <action id="Github.Workflow.ToolWindow.Show"
+                class="org.github.otanikotani.workflow.action.GitHubWorkflowShowActionGroup">
+            <add-to-group group-id="Git.Menu"/>
+        </action>
     </actions>
 
 </idea-plugin>


### PR DESCRIPTION
Fixes #36

The action is named `Open Workflow Tab` and can be found in `VCS -> Git`.
Its presentation replicates the GitHub built-in ones that can be found just above it: if only one GitHub repository is found the action group has no children, otherwise each child corresponds to a GH remote and is named following the pattern `<remote name>: <remote url>`.

The change in `GitHubWorkflowToolTabsContentManager#focusTab` is needed to open a new tab if it doesn't exist yet. I'm not sure if this is the best solution though.